### PR TITLE
Improve `--llvm-check`, make `musl` work and more!

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,14 @@
 release:
 	julia build_tarballs.jl --llvm-release
 
-debug:
-	julia build_tarballs.jl --llvm-debug
+reldbg:
+	julia build_tarballs.jl --llvm-reldbg
 
 check:
-	julia build_tarballs.jl --llvm-debug --llvm-check --verbose
+	julia build_tarballs.jl --llvm-check --verbose
 
 both:
-	julia build_tarballs.jl --llvm-debug
+	julia build_tarballs.jl --llvm-reldbg
 	julia build_tarballs.jl --llvm-release
 
 buildjl:

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -67,7 +67,6 @@ script = script_setup * raw"""
 # Build llvm-tblgen, clang-tblgen, and llvm-config
 mkdir build && cd build
 CMAKE_FLAGS="-DLLVM_TARGETS_TO_BUILD:STRING=host"
-CMAKE_FLAGS="${CMAKE_FLAGS} -DCMAKE_CXX_FLAGS=-std=c++0x"
 cmake .. ${CMAKE_FLAGS}
 make -j${nproc} llvm-tblgen clang-tblgen llvm-config
 
@@ -78,9 +77,9 @@ mv bin/clang-tblgen $prefix/bin/
 mv bin/llvm-config $prefix/bin/
 """
 
-# We'll do this build for x86_64-linux-gnu only, as that's the arch we're building on
+# We'll do this build for x86_64-linux-musl only, as that's the arch we're building on
 platforms = [
-    Linux(:x86_64),
+    Linux(:x86_64, :musl),
 ]
 
 # We only care about llvm-tblgen and clang-tblgen
@@ -99,16 +98,16 @@ filter!(s->!startswith(s, "--llvm"), ARGS)
 
 # Build the tarball, overriding ARGS so that the user doesn't shoot themselves in the foot,
 # but only do this if we don't already have a Tblgen tarball available:
-tblgen_tarball = joinpath("products", "tblgen.x86_64-linux-gnu.tar.gz")
+tblgen_tarball = joinpath("products", "tblgen.x86_64-linux-musl.tar.gz")
 if !isfile(tblgen_tarball)
-    tblgen_ARGS = ["x86_64-linux-gnu"]
+    tblgen_ARGS = ["x86_64-linux-musl"]
     if "--verbose" in ARGS
         push!(tblgen_ARGS, "--verbose")
     end
     product_hashes = build_tarballs(tblgen_ARGS, "tblgen", sources, script, platforms, products, dependencies)
 
     # Extract path information to the built tblgen tarball and its hash
-    tblgen_tarball, tblgen_hash = product_hashes["x86_64-linux-gnu"]
+    tblgen_tarball, tblgen_hash = product_hashes["x86_64-linux-musl"]
     tblgen_tarball = joinpath("products", tblgen_tarball)
 else
     info("Using pre-built tblgen tarball at $(tblgen_tarball)")

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -134,8 +134,11 @@ CMAKE_CPP_FLAGS=""
 CMAKE_CXX_FLAGS=""
 CMAKE_C_FLAGS=""
 
-# Start the cmake flags off with building for both our host arch, NVidia and AMD
-CMAKE_FLAGS="-DLLVM_TARGETS_TO_BUILD:STRING=\"host\;NVPTX\;AMDGPU\""
+CMAKE_FLAGS=""
+if [[ "${CHECK}" == "0" ]]; then
+    # Start the cmake flags off with building for both our host arch, NVidia and AMD
+    CMAKE_FLAGS="${CMAKE_FLAGS} -DLLVM_TARGETS_TO_BUILD:STRING=\"host\;NVPTX\;AMDGPU\""
+fi
 
 # Also target Wasm because Javascript is the Platform Of The Future (TM)
 CMAKE_FLAGS="${CMAKE_FLAGS} -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD:STRING=\"WebAssembly\""
@@ -222,7 +225,7 @@ make -j${nproc} VERBOSE=1
 
 # Test
 if [[ "${CHECK}" == "1" ]]; then
-make check -j${nproc}
+    make check -j${nproc}
 fi
 
 # Install!
@@ -283,6 +286,7 @@ end
 
 if "--llvm-check" in llvm_ARGS
    config *= "CHECK=1\n"
+   name *= ".check"
 else
    config *= "CHECK=0\n"
 end

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -1,3 +1,12 @@
+###
+# LLVMBuilder -- reliable LLVM builds all the time.
+#
+# --llvm-release: Build the release version on all supported platforms
+# --llvm-reldbg: Build the RelWithDebInfo+Asserts version
+# --llvm-check: Build a RelWithDebInfo+Asserts version on x86-64-linux-musl
+#               and run the testsuite. This will build for all targets.
+###
+
 using BinaryBuilder
 
 # Collection of sources required to build LLVM

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -218,6 +218,13 @@ if [[ "${target}" == *mingw* ]]; then
     CMAKE_FLAGS="${CMAKE_FLAGS} -DLLVM_POLLY_BUILD=OFF"
 fi
 
+if [[ "${target}" == *musl* ]]; then
+    # Taken from https://git.alpinelinux.org/cgit/aports/tree/main/compiler-rt/APKBUILD
+    CMAKE_FLAGS="${CMAKE_FLAGS} -DCOMPILER_RT_INCLUDE_TESTS=ON"
+    CMAKE_FLAGS="${CMAKE_FLAGS} -DCOMPILER_RT_BUILD_SANITIZERS=OFF"
+    CMAKE_FLAGS="${CMAKE_FLAGS} -DCOMPILER_RT_BUILD_XRAY=OFF"
+fi
+
 # Build!
 cmake .. ${CMAKE_FLAGS} -DCMAKE_C_FLAGS="${CMAKE_CPP_FLAGS} ${CMAKE_C_FLAGS}" -DCMAKE_CXX_FLAGS="${CMAKE_CPP_FLAGS} ${CMAKE_CXX_FLAGS}"
 cmake -LA || true

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -252,18 +252,26 @@ if [[ "${target}" == *mingw* ]]; then
 fi
 """
 
-# These are the platforms we will build for by default, unless further
-# platforms are passed in on the command line
-platforms = [
-    BinaryProvider.Linux(:i686, :glibc),
-    BinaryProvider.Linux(:x86_64, :glibc),
-    BinaryProvider.Linux(:aarch64, :glibc),
-    BinaryProvider.Linux(:armv7l, :glibc),
-    BinaryProvider.Linux(:powerpc64le, :glibc),
-    BinaryProvider.MacOS(),
-    BinaryProvider.Windows(:i686),
-    BinaryProvider.Windows(:x86_64)
-]
+if "--llvm-check" in llvm_ARGS
+   # BB is using musl as a platform and we don't want to run glibc binaries on it.
+   info("Restricting build to `x86_64-linux-musl`")
+   platforms = [
+        BinaryProvider.Linux(:x86_64, :musl)
+   ]
+else
+    # These are the platforms we will build for by default, unless further
+    # platforms are passed in on the command line
+    platforms = [
+        BinaryProvider.Linux(:i686, :glibc),
+        BinaryProvider.Linux(:x86_64, :glibc),
+        BinaryProvider.Linux(:aarch64, :glibc),
+        BinaryProvider.Linux(:armv7l, :glibc),
+        BinaryProvider.Linux(:powerpc64le, :glibc),
+        BinaryProvider.MacOS(),
+        BinaryProvider.Windows(:i686),
+        BinaryProvider.Windows(:x86_64)
+    ]
+end
 
 # The products that we will ensure are always built
 products(prefix) = [

--- a/patches/llvm_patches/0000-llvm-D27629-AArch64-large_model_4.0.patch
+++ b/patches/llvm_patches/0000-llvm-D27629-AArch64-large_model_4.0.patch
@@ -30,7 +30,7 @@ index 00000000000..e3eeb02ff01
 --- /dev/null
 +++ b/test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_BE-large-relocations.s
 @@ -0,0 +1,18 @@
-+# RUN: llvm-mc -triple=aarch64_be-none-linux-gnu -code-model=large -filetype=obj -o %T/be-large-reloc.o %s
++# RUN: llvm-mc -triple=aarch64_be-none-linux-gnu -large-code-model -filetype=obj -o %T/be-large-reloc.o %s
 +# RUN: llvm-rtdyld -triple=aarch64_be-none-linux-gnu -verify -map-section be-large-reloc.o,.eh_frame=0x10000 -map-section be-large-reloc.o,.text=0xffff000000000000 -check=%s %T/be-large-reloc.o
 +
 +        .text
@@ -54,7 +54,7 @@ index 00000000000..ec30f19c476
 --- /dev/null
 +++ b/test/ExecutionEngine/RuntimeDyld/AArch64/ELF_ARM64_large-relocations.s
 @@ -0,0 +1,18 @@
-+# RUN: llvm-mc -triple=arm64-none-linux-gnu -code-model=large -filetype=obj -o %T/large-reloc.o %s
++# RUN: llvm-mc -triple=arm64-none-linux-gnu -large-code-model -filetype=obj -o %T/large-reloc.o %s
 +# RUN: llvm-rtdyld -triple=arm64-none-linux-gnu -verify -map-section large-reloc.o,.eh_frame=0x10000 -map-section large-reloc.o,.text=0xffff000000000000 -check=%s %T/large-reloc.o
 +
 +        .text

--- a/patches/llvm_patches/0017-llvm-rL332694.patch
+++ b/patches/llvm_patches/0017-llvm-rL332694.patch
@@ -29,7 +29,7 @@ index 6285537df74..af7aca67c8f 100644
 @@ -1,5 +1,5 @@
  ; RUN: llc -mcpu=skylake-avx512 -mtriple=x86_64-unknown-linux-gnu %s -o - | FileCheck %s
 -; RUN: llc -mcpu=skylake-avx512 -mtriple=x86_64-unknown-linux-gnu %s -o - | llvm-mc
-+; RUN: llc -mcpu=skylake-avx512 -mtriple=x86_64-unknown-linux-gnu %s -o - | llvm-mc -triple=x86_64-unknown-linux-gnu
++; RUN: llc -mcpu=skylake-avx512 -mtriple=x86_64-unknown-linux-gnu %s -o - | llvm-mc -mcpu=skylake-avx512 -triple=x86_64-unknown-linux-gnu
  
  ; Check that the X86 domain reassignment pass doesn't introduce an illegal
  ; test instruction. See PR37396

--- a/patches/llvm_patches/0018-llvm-6.0-DISABLE_ABI_CHECKS.patch
+++ b/patches/llvm_patches/0018-llvm-6.0-DISABLE_ABI_CHECKS.patch
@@ -1,0 +1,39 @@
+From d793ba4bacae51ae25be19c1636fcf38707938fd Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Fri, 1 Jun 2018 17:43:55 -0400
+Subject: [PATCH] fix LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING
+
+---
+ cmake/modules/HandleLLVMOptions.cmake    | 2 +-
+ include/llvm/Config/abi-breaking.h.cmake | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/cmake/modules/HandleLLVMOptions.cmake b/cmake/modules/HandleLLVMOptions.cmake
+index 3d2dd48018c..b67ee6a896e 100644
+--- a/cmake/modules/HandleLLVMOptions.cmake
++++ b/cmake/modules/HandleLLVMOptions.cmake
+@@ -572,7 +572,7 @@ if (LLVM_ENABLE_WARNINGS AND (LLVM_COMPILER_IS_GCC_COMPATIBLE OR CLANG_CL))
+ 
+   if (LLVM_ENABLE_PEDANTIC AND LLVM_COMPILER_IS_GCC_COMPATIBLE)
+     append("-pedantic" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+-    append("-Wno-long-long" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
++    append("-Wno-long-long -Wundef" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+   endif()
+ 
+   add_flag_if_supported("-Wcovered-switch-default" COVERED_SWITCH_DEFAULT_FLAG)
+diff --git a/include/llvm/Config/abi-breaking.h.cmake b/include/llvm/Config/abi-breaking.h.cmake
+index 7ae401e5b8a..d52c4609101 100644
+--- a/include/llvm/Config/abi-breaking.h.cmake
++++ b/include/llvm/Config/abi-breaking.h.cmake
+@@ -20,7 +20,7 @@
+ 
+ /* Allow selectively disabling link-time mismatch checking so that header-only
+    ADT content from LLVM can be used without linking libSupport. */
+-#if !LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING
++#ifndef LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING
+ 
+ // ABI_BREAKING_CHECKS protection: provides link-time failure when clients build
+ // mismatch with LLVM
+-- 
+2.17.0
+

--- a/patches/llvm_patches/7003-compiler-rt-cmake-musl.patch
+++ b/patches/llvm_patches/7003-compiler-rt-cmake-musl.patch
@@ -1,0 +1,22 @@
+From fd82c5b9856b3876eaf323443e95d638ef625c5f Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Fri, 1 Jun 2018 17:02:25 -0400
+Subject: [PATCH] load CompilerRTCompile in fuzzer/test
+
+---
+ projects/compiler-rt/lib/fuzzer/tests/CMakeLists.txt | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/projects/compiler-rt/lib/fuzzer/tests/CMakeLists.txt b/projects/compiler-rt/lib/fuzzer/tests/CMakeLists.txt
+index cc3be7de2..c295b4639 100644
+--- a/projects/compiler-rt/lib/fuzzer/tests/CMakeLists.txt
++++ b/projects/compiler-rt/lib/fuzzer/tests/CMakeLists.txt
+@@ -1,3 +1,5 @@
++include(CompilerRTCompile)
++
+ set(LIBFUZZER_UNITTEST_CFLAGS
+   ${COMPILER_RT_UNITTEST_CFLAGS}
+   ${COMPILER_RT_GTEST_CFLAGS}
+-- 
+2.17.0
+


### PR DESCRIPTION
In BinaryBuilder our host system is musl based and if we want to run
the produced binaries within BB, we need to compile them for musl.