### PR TITLE
Backporting LLVM patch r355582 to release/6.x (fixes AVX512 max issue)

### DIFF
--- a/patches/llvm_patches/0029-llvm-r355582-avxminmax.patch
+++ b/patches/llvm_patches/0029-llvm-r355582-avxminmax.patch
@@ -1,0 +1,48 @@
+From 7f82bf14c02915ff1bf0e931465fc208287d24c6 Mon Sep 17 00:00:00 2001
+From: nic <nwerneck@gmail.com>
+Date: Thu, 7 Mar 2019 22:01:01 +0100
+Subject: [PATCH] Backporting r355582 on release/6.x
+
+---
+ lib/Target/X86/X86ISelLowering.cpp | 13 +++++++------
+ 1 file changed, 7 insertions(+), 6 deletions(-)
+
+diff --git a/lib/Target/X86/X86ISelLowering.cpp b/lib/Target/X86/X86ISelLowering.cpp
+index c1ddb771e2f..2a96373ed10 100644
+--- a/lib/Target/X86/X86ISelLowering.cpp
++++ b/lib/Target/X86/X86ISelLowering.cpp
+@@ -35751,15 +35751,17 @@ static SDValue combineFMinNumFMaxNum(SDNode *N, SelectionDAG &DAG,
+   if (Subtarget.useSoftFloat())
+     return SDValue();
+
++  const TargetLowering &TLI = DAG.getTargetLoweringInfo();
++
+   // TODO: Check for global or instruction-level "nnan". In that case, we
+   //       should be able to lower to FMAX/FMIN alone.
+   // TODO: If an operand is already known to be a NaN or not a NaN, this
+   //       should be an optional swap and FMAX/FMIN.
+
+   EVT VT = N->getValueType(0);
+-  if (!((Subtarget.hasSSE1() && (VT == MVT::f32 || VT == MVT::v4f32)) ||
+-        (Subtarget.hasSSE2() && (VT == MVT::f64 || VT == MVT::v2f64)) ||
+-        (Subtarget.hasAVX() && (VT == MVT::v8f32 || VT == MVT::v4f64))))
++  if (!((Subtarget.hasSSE1() && VT == MVT::f32) ||
++	(Subtarget.hasSSE2() && VT == MVT::f64) ||
++	(VT.isVector() && TLI.isTypeLegal(VT))))
+     return SDValue();
+
+   // This takes at least 3 instructions, so favor a library call when operating
+@@ -35770,9 +35772,8 @@ static SDValue combineFMinNumFMaxNum(SDNode *N, SelectionDAG &DAG,
+   SDValue Op0 = N->getOperand(0);
+   SDValue Op1 = N->getOperand(1);
+   SDLoc DL(N);
+-  EVT SetCCType = DAG.getTargetLoweringInfo().getSetCCResultType(
+-      DAG.getDataLayout(), *DAG.getContext(), VT);
+-
++  EVT SetCCType = TLI.getSetCCResultType(DAG.getDataLayout(), *DAG.getContext(),
++					 VT);
+   // There are 4 possibilities involving NaN inputs, and these are the required
+   // outputs:
+   //                   Op1
+--
+2.14.1


### PR DESCRIPTION
From https://github.com/JuliaLang/julia/pull/31292