### PR TITLE
Add Clang patch for -analyzer-werror

### DIFF
--- a/patches/llvm_patches/7004-clang-6.0-analyzer-Add-werror-flag-for-analyzer-warnings.patch
+++ b/patches/llvm_patches/7004-clang-6.0-analyzer-Add-werror-flag-for-analyzer-warnings.patch
@@ -1,0 +1,164 @@
+From 99590411e45f26b2cb6cdb8df9e7ebd2be181f1a Mon Sep 17 00:00:00 2001
+From: Keno Fischer <keno@juliacomputing.com>
+Date: Tue, 4 Jun 2019 19:43:29 -0400
+Subject: [PATCH] [analyzer] Add werror flag for analyzer warnings
+
+Summary:
+We're using the clang static analyzer together with a number of
+custom analyses in our CI system to ensure that certain invariants
+are statiesfied for by the code every commit. Unfortunately, there
+currently doesn't seem to be a good way to determine whether any
+analyzer warnings were emitted, other than parsing clang's output
+(or using scan-build, which then in turn parses clang's output).
+As a simpler mechanism, simply add a `-analyzer-werror` flag to CC1
+that causes the analyzer to emit its warnings as errors instead.
+I briefly tried to have this be `Werror=analyzer` and make it go
+through that machinery instead, but that seemed more trouble than
+it was worth in terms of conflicting with options to the actual build
+and special cases that would be required to circumvent the analyzers
+usual attempts to quiet non-analyzer warnings. This is simple and it
+works well.
+
+Reviewers: NoQ
+
+Subscribers: xazax.hun, baloghadamsoftware, szepet, a.sidorin, mikhail.ramalho, Szelethus, donat.nagy, dkrupp, Charusso, cfe-commits
+
+Tags: #clang
+
+Differential Revision: https://reviews.llvm.org/D62885
+---
+ include/clang/Driver/CC1Options.td               |  3 +++
+ .../clang/StaticAnalyzer/Core/AnalyzerOptions.h  |  4 ++++
+ lib/Frontend/CompilerInvocation.cpp              |  1 +
+ lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp | 16 ++++++++++++----
+ test/Analysis/override-werror.c                  |  9 ++++++---
+ 5 files changed, 26 insertions(+), 7 deletions(-)
+
+diff --git a/tools/clang/include/clang/Driver/CC1Options.td b/tools/clang/include/clang/Driver/CC1Options.td
+index 7dea88b62c..ba7f4acb1e 100644
+--- a/tools/clang/include/clang/Driver/CC1Options.td
++++ b/tools/clang/include/clang/Driver/CC1Options.td
+@@ -132,6 +132,9 @@ def analyzer_list_enabled_checkers : Flag<["-"], "analyzer-list-enabled-checkers
+ def analyzer_config : Separate<["-"], "analyzer-config">,
+   HelpText<"Choose analyzer options to enable">;
+ 
++def analyzer_werror : Flag<["-"], "analyzer-werror">,
++  HelpText<"Emit analyzer results as errors, not warnings">;
++
+ //===----------------------------------------------------------------------===//
+ // Migrator Options
+ //===----------------------------------------------------------------------===//
+diff --git a/tools/clang/include/clang/StaticAnalyzer/Core/AnalyzerOptions.h b/tools/clang/include/clang/StaticAnalyzer/Core/AnalyzerOptions.h
+index ce50cc582d..897800f4ca 100644
+--- a/tools/clang/include/clang/StaticAnalyzer/Core/AnalyzerOptions.h
++++ b/tools/clang/include/clang/StaticAnalyzer/Core/AnalyzerOptions.h
+@@ -177,6 +177,9 @@ public:
+   /// \brief Do not re-analyze paths leading to exhausted nodes with a different
+   /// strategy. We get better code coverage when retry is enabled.
+   unsigned NoRetryExhausted : 1;
++
++  /// Emit analyzer warnings as errors.
++  unsigned AnalyzerWerror : 1;
+   
+   /// \brief The inlining stack depth limit.
+   unsigned InlineMaxStackDepth;
+@@ -604,6 +607,7 @@ public:
+     UnoptimizedCFG(0),
+     PrintStats(0),
+     NoRetryExhausted(0),
++    AnalyzerWerror(0),
+     // Cap the stack depth at 4 calls (5 stack frames, base + 4 calls).
+     InlineMaxStackDepth(5),
+     InliningMode(NoRedundancy),
+diff --git a/tools/clang/lib/Frontend/CompilerInvocation.cpp b/tools/clang/lib/Frontend/CompilerInvocation.cpp
+index 438a48083e..086c9c446c 100644
+--- a/tools/clang/lib/Frontend/CompilerInvocation.cpp
++++ b/tools/clang/lib/Frontend/CompilerInvocation.cpp
+@@ -248,6 +248,7 @@ static bool ParseAnalyzerArgs(AnalyzerOptions &Opts, ArgList &Args,
+   Opts.visualizeExplodedGraphWithUbiGraph =
+     Args.hasArg(OPT_analyzer_viz_egraph_ubigraph);
+   Opts.NoRetryExhausted = Args.hasArg(OPT_analyzer_disable_retry_exhausted);
++  Opts.AnalyzerWerror = Args.hasArg(OPT_analyzer_werror);
+   Opts.AnalyzeAll = Args.hasArg(OPT_analyzer_opt_analyze_headers);
+   Opts.AnalyzerDisplayProgress = Args.hasArg(OPT_analyzer_display_progress);
+   Opts.AnalyzeNestedBlocks =
+diff --git a/tools/clang/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp b/tools/clang/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp
+index fccea9ee53..64834eb226 100644
+--- a/tools/clang/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp
++++ b/tools/clang/lib/StaticAnalyzer/Frontend/AnalysisConsumer.cpp
+@@ -83,10 +83,11 @@ void ento::createTextPathDiagnosticConsumer(AnalyzerOptions &AnalyzerOpts,
+ namespace {
+ class ClangDiagPathDiagConsumer : public PathDiagnosticConsumer {
+   DiagnosticsEngine &Diag;
+-  bool IncludePath;
++  bool IncludePath, Werror;
++
+ public:
+   ClangDiagPathDiagConsumer(DiagnosticsEngine &Diag)
+-    : Diag(Diag), IncludePath(false) {}
++      : Diag(Diag), IncludePath(false), Werror(false) {}
+   ~ClangDiagPathDiagConsumer() override {}
+   StringRef getName() const override { return "ClangDiags"; }
+ 
+@@ -101,9 +102,13 @@ public:
+     IncludePath = true;
+   }
+ 
++  void enableWerror() { Werror = true; }
++
+   void FlushDiagnosticsImpl(std::vector<const PathDiagnostic *> &Diags,
+                             FilesMade *filesMade) override {
+-    unsigned WarnID = Diag.getCustomDiagID(DiagnosticsEngine::Warning, "%0");
++    unsigned WarnID =
++        Werror ? Diag.getCustomDiagID(DiagnosticsEngine::Error, "%0")
++               : Diag.getCustomDiagID(DiagnosticsEngine::Warning, "%0");
+     unsigned NoteID = Diag.getCustomDiagID(DiagnosticsEngine::Note, "%0");
+ 
+     for (std::vector<const PathDiagnostic*>::iterator I = Diags.begin(),
+@@ -219,6 +224,9 @@ public:
+           new ClangDiagPathDiagConsumer(PP.getDiagnostics());
+       PathConsumers.push_back(clangDiags);
+ 
++      if (Opts->AnalyzerWerror)
++        clangDiags->enableWerror();
++
+       if (Opts->AnalysisDiagOpt == PD_TEXT) {
+         clangDiags->enablePaths();
+ 
+@@ -249,7 +257,7 @@ public:
+ #define ANALYSIS_CONSTRAINTS(NAME, CMDFLAG, DESC, CREATEFN)     \
+       case NAME##Model: CreateConstraintMgr = CREATEFN; break;
+ #include "clang/StaticAnalyzer/Core/Analyses.def"
+-    }
++    };
+   }
+ 
+   void DisplayFunction(const Decl *D, AnalysisMode Mode,
+diff --git a/tools/clang/test/Analysis/override-werror.c b/tools/clang/test/Analysis/override-werror.c
+index 7dc09f5186..df80bac84f 100644
+--- a/tools/clang/test/Analysis/override-werror.c
++++ b/tools/clang/test/Analysis/override-werror.c
+@@ -1,14 +1,17 @@
+ // RUN: %clang_analyze_cc1 -analyzer-checker=core,alpha.core -Werror %s -analyzer-store=region -verify
++// RUN: %clang_analyze_cc1 -analyzer-checker=core,alpha.core -Werror %s -analyzer-store=region -analyzer-werror -verify=werror
+ 
+ // This test case illustrates that using '-analyze' overrides the effect of
+ // -Werror.  This allows basic warnings not to interfere with producing
+ // analyzer results.
+ 
+-char* f(int *p) { 
+-  return p; // expected-warning{{incompatible pointer types}}
++char* f(int *p) {
++  return p; // expected-warning{{incompatible pointer types}} \
++               werror-warning{{incompatible pointer types}}
+ }
+ 
+ void g(int *p) {
+-  if (!p) *p = 0; // expected-warning{{null}}  
++  if (!p) *p = 0; // expected-warning{{null}} \
++                     werror-error{{null}}
+ }
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
This is a backport of
https://github.com/llvm/llvm-project/commit/6f48c076207f49dde437d85dbd5e1bcdd580f973